### PR TITLE
feat: WAF 보안 테스트 기능 구현 및 API 연결 수정

### DIFF
--- a/backend/src/waf-logs/waf-logs.service.ts
+++ b/backend/src/waf-logs/waf-logs.service.ts
@@ -149,7 +149,7 @@ export class WafLogsService {
   }
 
   // 보안 테스트 메서드들
-  async simulateSqlInjectionAttack(target = 'http://crs-nginx:8080') {
+  async simulateSqlInjectionAttack(target = 'http://localhost:8080') {
     const sqlPayloads = [
       "1' OR '1'='1",
       "1' UNION SELECT 1,2,3--",
@@ -207,7 +207,7 @@ export class WafLogsService {
     };
   }
 
-  async simulateXssAttack(target = 'http://crs-nginx:8080') {
+  async simulateXssAttack(target = 'http://localhost:8080') {
     const xssPayloads = [
       "<script>alert('XSS')</script>",
       "<img src=x onerror=alert('XSS')>",
@@ -265,7 +265,7 @@ export class WafLogsService {
     };
   }
 
-  async simulateCommandInjectionAttack(target = 'http://crs-nginx:8080') {
+  async simulateCommandInjectionAttack(target = 'http://localhost:8080') {
     const cmdPayloads = [
       "; ls -la",
       "| cat /etc/passwd",
@@ -327,7 +327,7 @@ export class WafLogsService {
     };
   }
 
-  async simulateDirectoryTraversalAttack(target = 'http://crs-nginx:8080') {
+  async simulateDirectoryTraversalAttack(target = 'http://localhost:8080') {
     const traversalPayloads = [
       "../../../etc/passwd",
       "..\\..\\..\\windows\\system32\\drivers\\etc\\hosts",
@@ -385,7 +385,7 @@ export class WafLogsService {
     };
   }
 
-  async simulateAllAttacks(target = 'http://crs-nginx:8080', count = 1) {
+  async simulateAllAttacks(target = 'http://localhost:8080', count = 1) {
     const results: Array<{
       round: number;
       sqlInjection: any;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import type { GetWafLogsDto, WafStatsDto } from '../types/waf.types';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3002';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 export const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
- 보안 테스트 API 엔드포인트 추가 (SQL Injection, XSS, Command Injection, Directory Traversal)
- 프론트엔드 API URL을 3001 포트로 수정
- WAF 타겟 URL을 localhost:8080으로 수정
- SecurityTestPanel 컴포넌트 추가
- 대시보드에 보안 테스트 탭 통합
- MongoDB 로그 저장 기능 구현